### PR TITLE
投稿検索機能

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -44,6 +44,10 @@ class PostsController < ApplicationController
     end
   end
 
+  def search
+    @posts = Post.search(params[:keyword])
+  end
+
   private
 
   def post_params

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,4 +14,12 @@ class Post < ApplicationRecord
     validates :image
     validates :category_id, :budget_id, :opening_hour_id, numericality: { other_than: 1, message: "can't be blank" }
   end
+
+  def self.search(search)
+    if search != ""
+      Post.where('title LIKE(?)', "%#{search}")
+    else
+      Post.all
+    end
+  end
 end

--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -1,0 +1,23 @@
+<%= render "shared/header" %>
+<div class="posts row">
+  <% @posts.each do |post| %>
+    <li class="list">
+      <%= link_to post_path(post.id) do %>
+        <div class="post-img-content">
+        <%= image_tag post.image.variant(resize: '300x300'), class: 'post-image' %>
+        </div>
+        <div class="post-info">
+          <div class="post-title">
+          <%= post.title %>
+          </div>
+          <div class="post-category">
+          <%= post.category.name %>
+          </div>
+        </div>
+      <% end %>
+        <div class="post-user">
+        <%= link_to "投稿者:#{post.user.nickname}", user_path(post.user), class: :post__user %>
+        </div>
+    </li>
+  <% end %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,4 +11,9 @@
   <% end %>
 
   </ul>
+
+  <%= form_with(url: search_posts_path, local: true, method: :get, class: "search-form") do |f|%>
+    <%= f.text_field :keyword, placeholder: "投稿を検索する", class: "search-input" %>
+    <%= f.submit "検索", class: "search-btn" %>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
   root to: "posts#index"
   resources :posts do
     resources :comments, only: :create
+    collection do
+      get 'search'
+    end
   end
   resources :users, only: [:show, :edit, :update]
 end


### PR DESCRIPTION
#What
投稿フォームを実装し、投稿内容の検索ができる。
#Why
検索フォームで検索したテキストを含む投稿を表示させることができるようにするため。